### PR TITLE
Prevent closing fills from triggering new signals

### DIFF
--- a/src/server/services/signals.ts
+++ b/src/server/services/signals.ts
@@ -66,6 +66,46 @@ async function scheduleHyperliquidRequest<T>(task: () => Promise<T>): Promise<T>
 
 const SIGNALS_FILE_PATH = 'signals.json';
 
+type SignalDirection = 'LONG' | 'SHORT';
+
+function classifyFillForSignal(fill: any): { signalType: SignalDirection } | null {
+  const tradeSize = Number.parseFloat(fill?.sz);
+  if (!Number.isFinite(tradeSize) || tradeSize <= 0) {
+    return null;
+  }
+
+  const normalizedDir = typeof fill?.dir === 'string' ? fill.dir.toLowerCase() : '';
+
+  if (normalizedDir.includes('close')) {
+    return null;
+  }
+
+  if (normalizedDir.includes('open')) {
+    if (normalizedDir.includes('long')) {
+      return { signalType: 'LONG' };
+    }
+
+    if (normalizedDir.includes('short')) {
+      return { signalType: 'SHORT' };
+    }
+  }
+
+  const startPosition = Number.parseFloat(fill?.startPosition);
+  if (!Number.isFinite(startPosition)) {
+    return null;
+  }
+
+  if (fill?.side === 'B' && startPosition >= 0) {
+    return { signalType: 'LONG' };
+  }
+
+  if (fill?.side === 'A' && startPosition <= 0) {
+    return { signalType: 'SHORT' };
+  }
+
+  return null;
+}
+
 export interface Signal {
   id: string;
   pair: string;
@@ -288,20 +328,16 @@ export async function detectAndSaveSignals(): Promise<void> {
   fillsByWallet.forEach(({ address, fills }) => {
     fills.forEach((fill: any) => {
       const isRecent = now - fill.time < timeWindowMs;
-      const startPosition = parseFloat(fill.startPosition);
-      const tradeSize = parseFloat(fill.sz);
-      const isOpeningTrade =
-        (fill.side === 'B' && startPosition >= 0 && tradeSize > 0) ||
-        (fill.side === 'A' && startPosition <= 0 && tradeSize > 0);
+      const classification = classifyFillForSignal(fill);
 
-      if (isRecent && isOpeningTrade) {
+      if (isRecent && classification) {
         const wallet = walletDataMap.get(address.toLowerCase());
         const cooldownTimestamp = wallet?.cooldowns?.[fill.coin];
         const isOnCooldown =
           cooldownTimestamp && now - new Date(cooldownTimestamp).getTime() < cooldownMs;
 
         if (!isOnCooldown) {
-          recentOpeningFills.push({ ...fill, walletAddress: address });
+          recentOpeningFills.push({ ...fill, walletAddress: address, signalType: classification.signalType });
         }
       }
     });
@@ -312,25 +348,33 @@ export async function detectAndSaveSignals(): Promise<void> {
     return;
   }
 
-  const fillsByPosition: Record<string, any[]> = {};
+  const fillsByPosition = new Map<string, { type: SignalDirection; fills: any[] }>();
   for (const fill of recentOpeningFills) {
-    const type = fill.side === 'B' ? 'LONG' : 'SHORT';
+    const type: SignalDirection | undefined = fill.signalType;
+    if (!type) {
+      continue;
+    }
+
     const key = `${fill.coin}-${type}`;
-    fillsByPosition[key] = fillsByPosition[key] ?? [];
-    fillsByPosition[key].push(fill);
+    const existing = fillsByPosition.get(key);
+    if (existing) {
+      existing.fills.push(fill);
+    } else {
+      fillsByPosition.set(key, { type, fills: [fill] });
+    }
   }
 
   const existingSignals = await readSignals();
   let newSignalsWereAdded = false;
 
-  for (const key in fillsByPosition) {
-    const positionFills = fillsByPosition[key].sort((a, b) => a.time - b.time);
+  for (const { type: signalType, fills: positionFills } of fillsByPosition.values()) {
+    const sortedFills = positionFills.sort((a, b) => a.time - b.time);
     let bestCluster: any[] | null = null;
 
-    for (let i = 0; i < positionFills.length; i++) {
-      const anchorFill = positionFills[i];
+    for (let i = 0; i < sortedFills.length; i++) {
+      const anchorFill = sortedFills[i];
       const windowEnd = anchorFill.time + timeWindowMs;
-      const windowFills = positionFills.filter((fill) => fill.time >= anchorFill.time && fill.time < windowEnd);
+      const windowFills = sortedFills.filter((fill) => fill.time >= anchorFill.time && fill.time < windowEnd);
       const uniqueWallets = new Set(windowFills.map((fill) => fill.walletAddress));
       if (uniqueWallets.size >= minWalletCount) {
         if (!bestCluster || uniqueWallets.size > new Set(bestCluster.map((fill) => fill.walletAddress)).size) {
@@ -351,8 +395,8 @@ export async function detectAndSaveSignals(): Promise<void> {
       continue;
     }
 
-    const { coin, side } = bestCluster[0];
-    const type = side === 'B' ? 'LONG' : 'SHORT';
+    const { coin } = bestCluster[0];
+    const type = signalType;
     const signalTimestamp = bestCluster.reduce((latest, fill) => Math.max(latest, fill.time), 0);
     const signalId = `${coin}-${type}-${signalTimestamp}`;
 


### PR DESCRIPTION
### **User description**
## Summary
- add a helper that classifies fills using the Hyperliquid direction metadata and falls back to the prior heuristics when needed
- only aggregate fills that were classified as openings and keep their signal direction when building clusters, preventing closing trades from being stored as entries

## Testing
- npm run lint *(fails: missing @opennextjs/cloudflare dependency required by the Next.js config)*

------
https://chatgpt.com/codex/tasks/task_b_68dd3f03e8ec8324806b714226103772


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent closing fills from triggering false signals

- Add fill classification using Hyperliquid direction metadata

- Improve signal detection logic with fallback heuristics

- Maintain signal direction consistency in clustering


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fill Data"] --> B["classifyFillForSignal()"]
  B --> C{"Is Closing Fill?"}
  C -->|Yes| D["Return null"]
  C -->|No| E{"Is Opening Fill?"}
  E -->|Yes| F["Return Signal Type"]
  E -->|No| G["Fallback Heuristics"]
  G --> H["Check Position & Side"]
  H --> F
  F --> I["Signal Clustering"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signals.ts</strong><dd><code>Improve signal detection with fill classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/signals.ts

<ul><li>Add <code>classifyFillForSignal()</code> function to filter closing fills<br> <li> Replace inline trade classification with new helper function<br> <li> Update clustering logic to use classified signal types<br> <li> Maintain signal direction consistency throughout processing</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/8/files#diff-ef359f0c1cca09f9820cff3756bf16b7da64fb86b3dead740ae7eb8afae5f0c8">+62/-18</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

