### PR TITLE
Track worker run timeouts and completion state

### DIFF
--- a/src/app/api/automation/run/route.ts
+++ b/src/app/api/automation/run/route.ts
@@ -3,29 +3,71 @@ import { getCloudflareContext } from '@opennextjs/cloudflare';
 
 import { detectAndSaveSignals, updateSignalPrices } from '@/server/services/signals';
 import { log } from '@/server/services/logs';
+import {
+  completeWorkerRun,
+  markStaleWorkerRuns,
+  registerWorkerRun,
+} from '@/server/services/workerRuns';
 import { setCloudflareEnv, type CloudflareBindings } from '@/server/storage/env';
 
 export async function POST() {
   const context = getCloudflareContext({ async: false });
   setCloudflareEnv(context.env as CloudflareBindings);
 
-  await log({ level: 'INFO', message: 'Cloudflare worker tick started' });
+  const runId = `${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const startedAt = Date.now();
+  let status: 'success' | 'error' = 'success';
+
+  const staleRuns = await markStaleWorkerRuns({
+    now: startedAt,
+    staleAfterMs: 10 * 60 * 1000,
+  });
+
+  for (const staleRun of staleRuns) {
+    await log({
+      level: 'ERROR',
+      message: 'Cloudflare worker tick inferred timeout',
+      context: {
+        runId: staleRun.runId,
+        startedAt: staleRun.startedAt,
+        lastUpdate: staleRun.updatedAt,
+      },
+    });
+  }
+
+  await registerWorkerRun({ runId, startedAt });
+  await log({ level: 'INFO', message: 'Cloudflare worker tick started', context: { runId } });
 
   try {
+    await log({ level: 'INFO', message: 'Detecting new signals', context: { runId } });
     await detectAndSaveSignals();
+    await log({ level: 'INFO', message: 'Updating signal prices', context: { runId } });
     await updateSignalPrices();
-    await log({ level: 'INFO', message: 'Cloudflare worker tick completed' });
     return NextResponse.json({ status: 'ok' });
   } catch (error) {
     const err = error as Error;
+    status = 'error';
     await log({
       level: 'ERROR',
       message: 'Cloudflare worker tick failed',
       context: {
+        runId,
         message: err.message,
         stack: err.stack,
       },
     });
     throw err;
+  } finally {
+    const durationMs = Date.now() - startedAt;
+    await completeWorkerRun({ runId, status, durationMs });
+    await log({
+      level: 'INFO',
+      message: status === 'success' ? 'Cloudflare worker tick completed' : 'Cloudflare worker tick ended with errors',
+      context: {
+        runId,
+        status,
+        durationMs,
+      },
+    });
   }
 }

--- a/src/server/services/logs.ts
+++ b/src/server/services/logs.ts
@@ -3,6 +3,35 @@ import { readJsonFile, writeJsonFile } from '../storage/jsonStore';
 const LOGS_FILE_PATH = 'logs.json';
 const defaultLogs: LogEntry[] = [];
 const MAX_LOG_ENTRIES = 200;
+const LOG_WRITE_RETRY_ATTEMPTS = 3;
+const LOG_WRITE_RETRY_DELAY_MS = 50;
+
+let logWriteQueue: Promise<void> = Promise.resolve();
+
+function sleep(durationMs: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, durationMs));
+}
+
+async function persistLog(entry: Omit<LogEntry, 'timestamp'>) {
+  const logs = await getLogs();
+  const history = Array.isArray(logs) ? logs : [];
+  const newLog: LogEntry = { ...entry, timestamp: new Date().toISOString() };
+  const updated = [newLog, ...history].slice(0, MAX_LOG_ENTRIES);
+  await writeJsonFile(LOGS_FILE_PATH, updated);
+}
+
+async function persistLogWithRetry(entry: Omit<LogEntry, 'timestamp'>, attempt = 1): Promise<void> {
+  try {
+    await persistLog(entry);
+  } catch (error) {
+    if (attempt >= LOG_WRITE_RETRY_ATTEMPTS) {
+      throw error;
+    }
+
+    await sleep(LOG_WRITE_RETRY_DELAY_MS * attempt);
+    await persistLogWithRetry(entry, attempt + 1);
+  }
+}
 
 export interface LogEntry {
   timestamp: string;
@@ -16,11 +45,13 @@ export async function getLogs(): Promise<LogEntry[]> {
 }
 
 export async function log(entry: Omit<LogEntry, 'timestamp'>): Promise<void> {
-  const logs = await getLogs();
-  const history = Array.isArray(logs) ? logs : [];
-  const newLog: LogEntry = { ...entry, timestamp: new Date().toISOString() };
-  const updated = [newLog, ...history].slice(0, MAX_LOG_ENTRIES);
-  await writeJsonFile(LOGS_FILE_PATH, updated);
+  logWriteQueue = logWriteQueue.catch(() => undefined).then(() => persistLogWithRetry(entry));
+
+  try {
+    await logWriteQueue;
+  } catch (error) {
+    console.error('Failed to persist log entry', error);
+  }
 }
 
 export async function clearLogs(): Promise<void> {

--- a/src/server/services/workerRuns.ts
+++ b/src/server/services/workerRuns.ts
@@ -1,0 +1,134 @@
+import { readJsonFile, writeJsonFile } from '../storage/jsonStore';
+
+const WORKER_RUNS_FILE_PATH = 'worker-runs.json';
+const defaultRuns: WorkerRunRecord[] = [];
+const MAX_WORKER_RUN_RECORDS = 100;
+
+export type WorkerRunStatus = 'running' | 'success' | 'error' | 'timeout';
+
+export interface WorkerRunRecord {
+  runId: string;
+  status: WorkerRunStatus;
+  startedAt: string;
+  updatedAt: string;
+  durationMs?: number;
+}
+
+async function readWorkerRuns(): Promise<WorkerRunRecord[]> {
+  const runs = await readJsonFile(WORKER_RUNS_FILE_PATH, defaultRuns);
+  return Array.isArray(runs) ? runs : defaultRuns;
+}
+
+async function writeWorkerRuns(runs: WorkerRunRecord[]): Promise<void> {
+  await writeJsonFile(WORKER_RUNS_FILE_PATH, runs.slice(0, MAX_WORKER_RUN_RECORDS));
+}
+
+interface MarkStaleWorkerRunsOptions {
+  now: number;
+  staleAfterMs: number;
+}
+
+export async function markStaleWorkerRuns({
+  now,
+  staleAfterMs,
+}: MarkStaleWorkerRunsOptions): Promise<WorkerRunRecord[]> {
+  const runs = await readWorkerRuns();
+  if (runs.length === 0) {
+    return [];
+  }
+
+  const nowIso = new Date(now).toISOString();
+  const staleThreshold = now - staleAfterMs;
+  const staleRuns: WorkerRunRecord[] = [];
+
+  const updatedRuns = runs.map((run) => {
+    if (run.status !== 'running') {
+      return run;
+    }
+
+    const startedTime = Date.parse(run.startedAt);
+    if (!Number.isFinite(startedTime) || startedTime >= staleThreshold) {
+      return run;
+    }
+
+    const timedOutRun: WorkerRunRecord = {
+      ...run,
+      status: 'timeout',
+      updatedAt: nowIso,
+    };
+
+    staleRuns.push(timedOutRun);
+    return timedOutRun;
+  });
+
+  if (staleRuns.length > 0) {
+    await writeWorkerRuns(updatedRuns);
+  }
+
+  return staleRuns;
+}
+
+interface RegisterWorkerRunOptions {
+  runId: string;
+  startedAt: number;
+}
+
+export async function registerWorkerRun({ runId, startedAt }: RegisterWorkerRunOptions): Promise<void> {
+  const runs = await readWorkerRuns();
+  const startedIso = new Date(startedAt).toISOString();
+  const updatedRuns: WorkerRunRecord[] = [
+    {
+      runId,
+      status: 'running',
+      startedAt: startedIso,
+      updatedAt: startedIso,
+    },
+    ...runs.filter((run) => run.runId !== runId),
+  ];
+
+  await writeWorkerRuns(updatedRuns);
+}
+
+interface CompleteWorkerRunOptions {
+  runId: string;
+  status: 'success' | 'error';
+  durationMs: number;
+}
+
+export async function completeWorkerRun({
+  runId,
+  status,
+  durationMs,
+}: CompleteWorkerRunOptions): Promise<void> {
+  const runs = await readWorkerRuns();
+  const updatedIso = new Date(Date.now()).toISOString();
+
+  let runFound = false;
+  const updatedRuns = runs.map((run) => {
+    if (run.runId !== runId) {
+      return run;
+    }
+
+    const completedRun: WorkerRunRecord = {
+      ...run,
+      status,
+      durationMs,
+      updatedAt: updatedIso,
+    };
+
+    runFound = true;
+    return completedRun;
+  });
+
+  if (!runFound) {
+    updatedRuns.unshift({
+      runId,
+      status,
+      startedAt: updatedIso,
+      updatedAt: updatedIso,
+      durationMs,
+    });
+  }
+
+  await writeWorkerRuns(updatedRuns);
+}


### PR DESCRIPTION
### **User description**
## Summary
- track Cloudflare worker runs in persistent storage so each tick has an explicit lifecycle record
- flag any stale "running" entries as timeouts before starting a new tick and emit diagnostic logs for them
- update the stored run entry when the tick finishes so completion metadata is always captured

## Testing
- npm run lint *(fails: Cannot find module '@opennextjs/cloudflare')*

------
https://chatgpt.com/codex/tasks/task_b_68e14a019ab083249eea7d44165d5308


___

### **PR Type**
Enhancement


___

### **Description**
- Add worker run lifecycle tracking with persistent storage

- Implement timeout detection for stale running workers

- Enhance logging with run context and retry mechanism

- Add completion state tracking with duration metrics


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Worker Start"] --> B["Mark Stale Runs"]
  B --> C["Register New Run"]
  C --> D["Execute Tasks"]
  D --> E["Complete Run"]
  B --> F["Log Timeouts"]
  E --> G["Log Completion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add worker run lifecycle management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app/api/automation/run/route.ts

<ul><li>Generate unique run IDs and track worker execution lifecycle<br> <li> Mark stale running workers as timed out before starting new runs<br> <li> Add run context to all log messages for better traceability<br> <li> Implement finally block to ensure completion state is always recorded</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/15/files#diff-28f3ab620f261fab44402f70e75926c78c9fdf981cd51d1b2475e1dab7f882e6">+44/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>logs.ts</strong><dd><code>Enhance logging with retry mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/logs.ts

<ul><li>Implement log write queue to prevent concurrent write conflicts<br> <li> Add retry mechanism with exponential backoff for failed log writes<br> <li> Extract log persistence logic into separate functions<br> <li> Add error handling for log write failures</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/15/files#diff-ff77a171960b7559c613b8abf05aed19970a864b08a0628f53e603f91a2b0561">+36/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workerRuns.ts</strong><dd><code>Create worker run tracking service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/workerRuns.ts

<ul><li>Create new service for managing worker run records in persistent <br>storage<br> <li> Implement functions to register, complete, and mark stale worker runs<br> <li> Define WorkerRunRecord interface with status tracking<br> <li> Add timeout detection logic with configurable thresholds</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/15/files#diff-fd04cb97702999b1d14c5bbbcb54e3bfd45b4c69c5bfac796ab60baa6f6e2af9">+134/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

