### PR TITLE
Add timeout handling for Hyperliquid requests

### DIFF
--- a/src/server/services/signals.ts
+++ b/src/server/services/signals.ts
@@ -7,6 +7,10 @@ const HYPERLIQUID_MIN_REQUEST_INTERVAL_MS = Math.max(
   0,
   Number(process.env.HYPERLIQUID_MIN_REQUEST_INTERVAL_MS ?? 1_000)
 );
+const HYPERLIQUID_REQUEST_TIMEOUT_MS = Math.max(
+  1_000,
+  Number(process.env.HYPERLIQUID_REQUEST_TIMEOUT_MS ?? 15_000)
+);
 const USER_FILLS_MAX_RETRIES = Math.max(1, Number(process.env.USER_FILLS_MAX_RETRIES ?? 5));
 const USER_FILLS_INITIAL_BACKOFF_MS = Math.max(
   250,
@@ -16,10 +20,38 @@ const USER_FILLS_MAX_BACKOFF_MS = Math.max(
   USER_FILLS_INITIAL_BACKOFF_MS,
   Number(process.env.USER_FILLS_MAX_BACKOFF_MS ?? 60_000)
 );
+const HYPERLIQUID_TIMEOUT_PENALTY_MS = Math.max(
+  HYPERLIQUID_MIN_REQUEST_INTERVAL_MS,
+  HYPERLIQUID_REQUEST_TIMEOUT_MS,
+  USER_FILLS_INITIAL_BACKOFF_MS
+);
 
 const hyperliquidBaseUrl = 'https://api.hyperliquid.xyz/info';
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+class RequestTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RequestTimeoutError';
+  }
+}
+
+async function fetchWithTimeout(input: string, init: RequestInit, timeoutMs: number): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    return await fetch(input, { ...init, signal: controller.signal });
+  } catch (error: any) {
+    if (error?.name === 'AbortError') {
+      throw new RequestTimeoutError(`Hyperliquid request timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
 
 let hyperliquidQueue: Promise<void> = Promise.resolve();
 let lastHyperliquidRequestTimestamp = 0;
@@ -140,11 +172,15 @@ async function writeSignals(signals: Signal[]): Promise<void> {
 async function getMarkPrice(coin: string): Promise<string> {
   try {
     const { response, body } = await scheduleHyperliquidRequest(async () => {
-      const response = await fetch(hyperliquidBaseUrl, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ type: 'allMids' }),
-      });
+      const response = await fetchWithTimeout(
+        hyperliquidBaseUrl,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ type: 'allMids' }),
+        },
+        HYPERLIQUID_REQUEST_TIMEOUT_MS
+      );
 
       let body: any = null;
       try {
@@ -170,7 +206,16 @@ async function getMarkPrice(coin: string): Promise<string> {
 
     return body[coin] ?? '0.00';
   } catch (error: any) {
-    await log({ level: 'ERROR', message: `Failed to fetch mark price for ${coin}`, context: { error: error.message } });
+    if (error instanceof RequestTimeoutError) {
+      registerHyperliquidPenalty(HYPERLIQUID_TIMEOUT_PENALTY_MS);
+      await log({
+        level: 'WARN',
+        message: `Hyperliquid request timed out while fetching mark price for ${coin}`,
+        context: { timeoutMs: HYPERLIQUID_REQUEST_TIMEOUT_MS },
+      });
+    } else {
+      await log({ level: 'ERROR', message: `Failed to fetch mark price for ${coin}`, context: { error: error.message } });
+    }
     return '0.00';
   }
 }
@@ -181,11 +226,15 @@ async function getUserFills(address: string): Promise<any[]> {
   for (let attempt = 1; attempt <= USER_FILLS_MAX_RETRIES; attempt++) {
     try {
       const { response, body } = await scheduleHyperliquidRequest(async () => {
-        const response = await fetch(hyperliquidBaseUrl, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ type: 'userFills', user: address }),
-        });
+        const response = await fetchWithTimeout(
+          hyperliquidBaseUrl,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ type: 'userFills', user: address }),
+          },
+          HYPERLIQUID_REQUEST_TIMEOUT_MS
+        );
 
         let body: any = null;
         try {
@@ -224,21 +273,33 @@ async function getUserFills(address: string): Promise<any[]> {
       });
       return [];
     } catch (error: any) {
+      const isTimeout = error instanceof RequestTimeoutError;
       const message = error?.message ?? 'Unknown error';
+
       if (attempt >= USER_FILLS_MAX_RETRIES) {
         await log({
           level: 'ERROR',
           message: `Failed to fetch user fills for ${address}`,
-          context: { error: message, attempt },
+          context: { error: message, attempt, timeout: isTimeout },
         });
         break;
       }
 
-      await log({
-        level: 'WARN',
-        message: `Retrying user fills request for ${address}`,
-        context: { error: message, attempt },
-      });
+      if (isTimeout) {
+        await log({
+          level: 'WARN',
+          message: `Hyperliquid request timed out while fetching user fills for ${address}`,
+          context: { attempt, timeoutMs: HYPERLIQUID_REQUEST_TIMEOUT_MS },
+        });
+        registerHyperliquidPenalty(HYPERLIQUID_TIMEOUT_PENALTY_MS);
+      } else {
+        await log({
+          level: 'WARN',
+          message: `Retrying user fills request for ${address}`,
+          context: { error: message, attempt },
+        });
+      }
+
       await sleep(backoff);
       backoff = Math.min(backoff * 2, USER_FILLS_MAX_BACKOFF_MS);
     }


### PR DESCRIPTION
### **User description**
## Summary
- add configurable timeout handling for Hyperliquid API calls
- introduce retry logging for request timeouts and penalize the scheduler to prevent rapid replays
- reuse the new timeout helper in mark-price and user-fills fetches to avoid long-running worker executions

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68e31234bb6083248fcff9048929f70b


___

### **PR Type**
Enhancement


___

### **Description**
- Add configurable timeout handling for Hyperliquid API requests

- Implement retry penalty mechanism for timeout scenarios

- Replace direct fetch calls with timeout-aware wrapper

- Enhance error logging with timeout-specific messages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hyperliquid API Request"] --> B["fetchWithTimeout wrapper"]
  B --> C["AbortController timeout"]
  C --> D["RequestTimeoutError"]
  D --> E["Penalty scheduler"]
  E --> F["Enhanced logging"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signals.ts</strong><dd><code>Implement timeout handling for Hyperliquid requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/signals.ts

<ul><li>Add <code>HYPERLIQUID_REQUEST_TIMEOUT_MS</code> and <code>HYPERLIQUID_TIMEOUT_PENALTY_MS</code> <br>configuration constants<br> <li> Implement <code>RequestTimeoutError</code> class and <code>fetchWithTimeout</code> helper <br>function<br> <li> Replace direct <code>fetch</code> calls in <code>getMarkPrice</code> and <code>getUserFills</code> with <br>timeout wrapper<br> <li> Add timeout-specific error handling and penalty registration for <br>scheduler</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/16/files#diff-ef359f0c1cca09f9820cff3756bf16b7da64fb86b3dead740ae7eb8afae5f0c8">+78/-17</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

