### PR TITLE
Optimize signal clustering window to reduce cron CPU usage

### DIFF
--- a/src/server/services/signals.ts
+++ b/src/server/services/signals.ts
@@ -777,20 +777,48 @@ export async function detectAndSaveSignals(options: DetectSignalsOptions = {}): 
     const sortedFills = positionFills.sort((a, b) => a.time - b.time);
     let bestCluster: any[] | null = null;
 
-    for (let i = 0; i < sortedFills.length; i++) {
+    const walletCounts = new Map<string, number>();
+    let startIndex = 0;
+    let bestUniqueWalletCount = 0;
+
+    for (let endIndex = 0; endIndex < sortedFills.length; endIndex++) {
       if (overallDeadlineExceeded()) {
         detectionAborted = true;
         break;
       }
 
-      const anchorFill = sortedFills[i];
-      const windowEnd = anchorFill.time + timeWindowMs;
-      const windowFills = sortedFills.filter((fill) => fill.time >= anchorFill.time && fill.time < windowEnd);
-      const uniqueWallets = new Set(windowFills.map((fill) => fill.walletAddress));
-      if (uniqueWallets.size >= minWalletCount) {
-        if (!bestCluster || uniqueWallets.size > new Set(bestCluster.map((fill) => fill.walletAddress)).size) {
-          bestCluster = windowFills;
+      const endFill = sortedFills[endIndex];
+      const endWallet = String(endFill.walletAddress ?? '__unknown__');
+      walletCounts.set(endWallet, (walletCounts.get(endWallet) ?? 0) + 1);
+
+      while (
+        startIndex <= endIndex &&
+        sortedFills[endIndex].time - sortedFills[startIndex].time >= timeWindowMs
+      ) {
+        const startFill = sortedFills[startIndex];
+        const startWallet = String(startFill.walletAddress ?? '__unknown__');
+        const remaining = (walletCounts.get(startWallet) ?? 0) - 1;
+        if (remaining > 0) {
+          walletCounts.set(startWallet, remaining);
+        } else {
+          walletCounts.delete(startWallet);
         }
+        startIndex += 1;
+
+        if (overallDeadlineExceeded()) {
+          detectionAborted = true;
+          break;
+        }
+      }
+
+      if (detectionAborted) {
+        break;
+      }
+
+      const uniqueWalletCount = walletCounts.size;
+      if (uniqueWalletCount >= minWalletCount && uniqueWalletCount > bestUniqueWalletCount) {
+        bestUniqueWalletCount = uniqueWalletCount;
+        bestCluster = sortedFills.slice(startIndex, endIndex + 1);
       }
     }
 


### PR DESCRIPTION
### **User description**
## Summary
- replace the signal clustering scan with a linear-time sliding window so cron executions spend less CPU identifying qualifying fills
- preserve existing deadline handling and wallet tracking semantics while updating the unique-wallet selection logic

## Testing
- npm run lint *(fails: local environment missing @opennextjs/cloudflare, required by Next.js config)*

------
https://chatgpt.com/codex/tasks/task_b_68e86ac0298c8324ad5cf4026d29cdd4


___

### **PR Type**
Enhancement


___

### **Description**
- Replace O(n²) signal clustering with O(n) sliding window algorithm

- Optimize CPU usage for cron job executions

- Preserve deadline handling and wallet tracking semantics

- Improve unique wallet selection logic efficiency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Sorted Fills"] --> B["Sliding Window"]
  B --> C["Wallet Count Map"]
  C --> D["Best Cluster Selection"]
  D --> E["Optimized Signal Detection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signals.ts</strong><dd><code>Sliding window signal clustering optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/signals.ts

<ul><li>Replace nested loop clustering with sliding window approach<br> <li> Use Map to track wallet counts within time window<br> <li> Maintain window boundaries with start/end indices<br> <li> Preserve deadline checking and abort logic</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/29/files#diff-ef359f0c1cca09f9820cff3756bf16b7da64fb86b3dead740ae7eb8afae5f0c8">+36/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

