### PR TITLE
Scale signal detection runtime with tracked wallet count

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ HyperSignal is a Next.js dashboard that monitors Hyperliquid wallets, clusters f
 
 - **Cloudflare Workers (OpenNext)** serve the Next.js dashboard, API routes, and background automation from a single worker script.
 - **Cloudflare D1** stores all persistent state (signals, wallets, settings, analytics, logs) and is exposed to the worker under the binding name `DB`.
-- **Cloudflare Workers Cron** triggers the same worker every five minutes so detection continues 24/7 even when no browser is open.
+- **Cloudflare Workers Cron** triggers the same worker every ten minutes so detection continues 24/7 even when no browser is open.
 
 ## Prerequisites
 
@@ -49,13 +49,14 @@ Use `npm run upload` if you only want to push the assets without publishing, or 
 ### 3. Verify the live dashboard
 
 1. Open the worker's deployed URL. The dashboard will call the bundled API routes which talk to D1.
-2. Use the **Workers → Triggers** tab to confirm the cron schedule (`*/5 * * * *`) is active.
+2. Use the **Workers → Triggers** tab to confirm the cron schedule (`*/10 * * * *`) is active.
 3. Inspect the **Logs** tab or the in-app Logs page to confirm the automation route runs on every cron tick.
 
 ## Architecture overview
 
 - **Cloudflare-first persistence** – `src/server/storage/jsonStore.ts` stores structured JSON data in the D1 table `kv_store`, so every part of the app (UI, APIs, worker automation) shares the same durable backend.
-- **Automation inside the Worker** – `src/app/api/automation/run/route.ts` encapsulates the background job. Cron triggers call this route through the generated worker, reusing the same service layer and logging progress back into D1.
+- **Automation inside the Worker** – `src/app/api/automation/run/route.ts` encapsulates the background job. Cron triggers call this route through the generated worker, reusing the same service layer and logging progress back into D1. The route now enforces a cooldown aligned with the 10-minute cron so free-tier Workers never overlap.
+- **Runtime-aware signal detection** – `src/server/services/signals.ts` scales its runtime budget based on the number of tracked wallets, ensuring every scan completes even on the Cloudflare free tier. The defaults can be tuned with `DETECTION_MIN_RUNTIME_BUDGET_MS` and `DETECTION_RUNTIME_BUDGET_PER_WALLET_MS` if you need to expand or tighten the window.
 - **API consumption from the UI** – Front-end pages call the REST endpoints served by the Next.js app on Cloudflare Workers. Because everything runs on the same origin you don’t need extra configuration—the dashboard simply polls `/api/**` routes.
 
 ## Useful scripts

--- a/src/app/api/automation/run/route.ts
+++ b/src/app/api/automation/run/route.ts
@@ -10,6 +10,7 @@ import {
   registerWorkerRun,
   touchWorkerRun,
 } from '@/server/services/workerRuns';
+import { readWorkerState } from '@/server/services/workerState';
 import { setCloudflareEnv, type CloudflareBindings } from '@/server/storage/env';
 
 const AUTOMATION_TICK_TIME_LIMIT_MS = Math.max(
@@ -22,7 +23,11 @@ const AUTOMATION_TICK_COMPLETION_BUFFER_MS = Math.max(
 );
 const AUTOMATION_ACTIVE_RUN_GRACE_MS = Math.max(
   15_000,
-  Number(process.env.AUTOMATION_ACTIVE_RUN_GRACE_MS ?? 90_000)
+  Number(process.env.AUTOMATION_ACTIVE_RUN_GRACE_MS ?? 12 * 60_000)
+);
+const AUTOMATION_MIN_INTERVAL_MS = Math.max(
+  5 * 60_000,
+  Number(process.env.AUTOMATION_MIN_INTERVAL_MS ?? 10 * 60_000)
 );
 
 export async function POST() {
@@ -33,6 +38,47 @@ export async function POST() {
   const startedAt = Date.now();
   const automationDeadline = startedAt + AUTOMATION_TICK_TIME_LIMIT_MS;
   let status: 'success' | 'error' = 'success';
+
+  const workerState = await readWorkerState();
+  const lastDetectionRunStartedAt = workerState.lastDetectionRunStartedAt
+    ? Date.parse(workerState.lastDetectionRunStartedAt)
+    : NaN;
+  const lastDetectionRunCompletedAt = workerState.lastDetectionRunCompletedAt
+    ? Date.parse(workerState.lastDetectionRunCompletedAt)
+    : NaN;
+
+  const referenceTimestamp = Number.isFinite(lastDetectionRunStartedAt)
+    ? lastDetectionRunStartedAt
+    : lastDetectionRunCompletedAt;
+
+  if (Number.isFinite(referenceTimestamp)) {
+    const sinceLastRunMs = startedAt - referenceTimestamp;
+    if (sinceLastRunMs < AUTOMATION_MIN_INTERVAL_MS) {
+      const cooldownRemainingMs = AUTOMATION_MIN_INTERVAL_MS - sinceLastRunMs;
+      await log({
+        level: 'INFO',
+        message: 'Cloudflare worker tick skipped due to cooldown window.',
+        context: {
+          runId,
+          startedAt,
+          lastDetectionRunStartedAt: workerState.lastDetectionRunStartedAt,
+          lastDetectionRunCompletedAt: workerState.lastDetectionRunCompletedAt,
+          lastDetectionRunDurationMs: workerState.lastDetectionRunDurationMs,
+          cooldownRemainingMs,
+          minIntervalMs: AUTOMATION_MIN_INTERVAL_MS,
+        },
+      });
+
+      return NextResponse.json(
+        {
+          status: 'skipped',
+          reason: 'cooldown',
+          cooldownRemainingMs,
+        },
+        { status: 202 }
+      );
+    }
+  }
 
   const staleRuns = await markStaleWorkerRuns({
     now: startedAt,

--- a/src/server/services/signals.ts
+++ b/src/server/services/signals.ts
@@ -4,7 +4,7 @@ import { readJsonFile, writeJsonFile } from '../storage/jsonStore';
 import { getTrackedWalletsWithCooldown, readWallets, updateWalletCooldowns, writeWallets } from './wallets';
 import { getSettings, Settings } from './settings';
 import { log } from './logs';
-import { advanceWorkerWalletCursor, readWorkerState, writeWorkerState } from './workerState';
+import { writeWorkerState } from './workerState';
 
 const HYPERLIQUID_MIN_REQUEST_INTERVAL_MS = Math.max(
   0,
@@ -28,22 +28,18 @@ const HYPERLIQUID_TIMEOUT_PENALTY_MS = Math.max(
   HYPERLIQUID_REQUEST_TIMEOUT_MS,
   USER_FILLS_INITIAL_BACKOFF_MS
 );
-const DETECTION_RUN_TIME_LIMIT_MS = Math.max(
-  30_000,
-  Number(process.env.DETECTION_RUN_TIME_LIMIT_MS ?? 60_000)
+const DETECTION_MIN_RUNTIME_BUDGET_MS = Math.max(
+  60_000,
+  Number(process.env.DETECTION_MIN_RUNTIME_BUDGET_MS ?? 180_000)
+);
+const DETECTION_RUNTIME_BUDGET_PER_WALLET_MS = Math.max(
+  HYPERLIQUID_MIN_REQUEST_INTERVAL_MS,
+  Number(process.env.DETECTION_RUNTIME_BUDGET_PER_WALLET_MS ?? 2_500)
 );
 const DETECTION_RUN_WARNING_THRESHOLD_MS = Math.max(
-  15_000,
-  Math.min(
-    Number(process.env.DETECTION_RUN_WARNING_THRESHOLD_MS ?? 45_000),
-    DETECTION_RUN_TIME_LIMIT_MS
-  )
+  30_000,
+  Number(process.env.DETECTION_RUN_WARNING_THRESHOLD_MS ?? 90_000)
 );
-const DETECTION_MAX_WALLETS_PER_RUN = Math.max(
-  1,
-  Number(process.env.DETECTION_MAX_WALLETS_PER_RUN ?? 20)
-);
-
 const TELEGRAM_REQUEST_TIMEOUT_MS = Math.max(
   5_000,
   Number(process.env.TELEGRAM_REQUEST_TIMEOUT_MS ?? 15_000)
@@ -546,19 +542,26 @@ export async function detectAndSaveSignals(options: DetectSignalsOptions = {}): 
 
   if (trackedAddresses.length === 0 || minWalletCount <= 0 || timeWindow <= 0) {
     await log({ level: 'INFO', message: 'Signal detection skipped: Insufficient configuration or no tracked wallets.' });
+    const nowIso = new Date().toISOString();
     await writeWorkerState({
-      nextWalletIndex: 0,
-      lastDetectionRunAt: new Date().toISOString(),
+      lastDetectionRunStartedAt: nowIso,
+      lastDetectionRunCompletedAt: nowIso,
       lastDetectionRunDurationMs: 0,
     });
     return;
   }
 
   const detectionStartedAt = Date.now();
+  const detectionStartedAtIso = new Date(detectionStartedAt).toISOString();
+  await writeWorkerState({ lastDetectionRunStartedAt: detectionStartedAtIso });
   const overallDeadlineCandidate = options.deadlineMs ?? Number.POSITIVE_INFINITY;
+  const computedRuntimeBudgetMs = Math.max(
+    DETECTION_MIN_RUNTIME_BUDGET_MS,
+    trackedAddresses.length * DETECTION_RUNTIME_BUDGET_PER_WALLET_MS
+  );
   const fetchDeadlineCandidate = Math.min(
     overallDeadlineCandidate,
-    detectionStartedAt + DETECTION_RUN_TIME_LIMIT_MS
+    detectionStartedAt + computedRuntimeBudgetMs
   );
   const fetchDeadline = Number.isFinite(fetchDeadlineCandidate)
     ? fetchDeadlineCandidate
@@ -566,17 +569,16 @@ export async function detectAndSaveSignals(options: DetectSignalsOptions = {}): 
   const overallDeadline = Number.isFinite(overallDeadlineCandidate)
     ? overallDeadlineCandidate
     : undefined;
-  const workerState = await readWorkerState();
-  const startIndex =
-    trackedAddresses.length > 0
-      ? workerState.nextWalletIndex % trackedAddresses.length
-      : 0;
-  const rotatedAddresses = [
-    ...trackedAddresses.slice(startIndex),
-    ...trackedAddresses.slice(0, startIndex),
-  ];
-  const maxWalletsThisRun = Math.min(rotatedAddresses.length, DETECTION_MAX_WALLETS_PER_RUN);
-  const addressesThisRun = rotatedAddresses.slice(0, maxWalletsThisRun);
+  const addressesThisRun = [...trackedAddresses];
+  const runtimeBudgetMs =
+    fetchDeadline !== undefined ? Math.max(fetchDeadline - detectionStartedAt, 0) : null;
+  const warningThresholdMs =
+    runtimeBudgetMs !== null
+      ? Math.min(
+          Math.max(DETECTION_RUN_WARNING_THRESHOLD_MS, Math.floor(computedRuntimeBudgetMs * 0.75)),
+          runtimeBudgetMs
+        )
+      : Math.max(DETECTION_RUN_WARNING_THRESHOLD_MS, Math.floor(computedRuntimeBudgetMs * 0.75));
 
   const fillsByWallet: { address: string; fills: any[] }[] = [];
   let detectionAborted = false;
@@ -650,14 +652,12 @@ export async function detectAndSaveSignals(options: DetectSignalsOptions = {}): 
     }
   }
 
-  await advanceWorkerWalletCursor({
-    processedWallets: fillsByWallet.length,
-    totalWallets: trackedAddresses.length,
-  });
-
-  const detectionDurationMs = Date.now() - detectionStartedAt;
+  const detectionCompletedAt = Date.now();
+  const detectionDurationMs = detectionCompletedAt - detectionStartedAt;
+  const detectionCompletedAtIso = new Date(detectionCompletedAt).toISOString();
   await writeWorkerState({
-    lastDetectionRunAt: new Date().toISOString(),
+    lastDetectionRunStartedAt: detectionStartedAtIso,
+    lastDetectionRunCompletedAt: detectionCompletedAtIso,
     lastDetectionRunDurationMs: detectionDurationMs,
   });
 
@@ -673,10 +673,11 @@ export async function detectAndSaveSignals(options: DetectSignalsOptions = {}): 
         durationMs: detectionDurationMs,
         detectionDeadlineMs: fetchDeadline ?? null,
         automationDeadlineMs: overallDeadline ?? null,
-        batchSizeLimit: DETECTION_MAX_WALLETS_PER_RUN,
+        runtimeBudgetMs,
+        targetRuntimeBudgetMs: computedRuntimeBudgetMs,
       },
     });
-  } else if (detectionDurationMs >= DETECTION_RUN_WARNING_THRESHOLD_MS) {
+  } else if (detectionDurationMs >= warningThresholdMs) {
     await log({
       level: 'WARN',
       message: 'Signal detection run approached the runtime warning threshold.',
@@ -684,19 +685,21 @@ export async function detectAndSaveSignals(options: DetectSignalsOptions = {}): 
         processedWallets: fillsByWallet.length,
         totalWallets: trackedAddresses.length,
         durationMs: detectionDurationMs,
-        warningThresholdMs: DETECTION_RUN_WARNING_THRESHOLD_MS,
-        batchSizeLimit: DETECTION_MAX_WALLETS_PER_RUN,
+        warningThresholdMs,
+        runtimeBudgetMs,
+        targetRuntimeBudgetMs: computedRuntimeBudgetMs,
       },
     });
   } else if (fillsByWallet.length > 0) {
     await log({
       level: 'INFO',
-      message: 'Signal detection processed wallet batch within limits.',
+      message: 'Signal detection scanned all wallets within limits.',
       context: {
         processedWallets: fillsByWallet.length,
         totalWallets: trackedAddresses.length,
         durationMs: detectionDurationMs,
-        batchSizeLimit: DETECTION_MAX_WALLETS_PER_RUN,
+        runtimeBudgetMs,
+        targetRuntimeBudgetMs: computedRuntimeBudgetMs,
       },
     });
   }

--- a/src/server/services/workerState.ts
+++ b/src/server/services/workerState.ts
@@ -3,46 +3,96 @@ import { readJsonFile, writeJsonFile } from '../storage/jsonStore';
 const WORKER_STATE_FILE_PATH = 'worker-state.json';
 
 export interface WorkerState {
-  nextWalletIndex: number;
-  lastDetectionRunAt: string | null;
+  lastDetectionRunStartedAt: string | null;
+  lastDetectionRunCompletedAt: string | null;
   lastDetectionRunDurationMs: number | null;
 }
 
-const defaultWorkerState: WorkerState = {
+type StoredWorkerState = WorkerState & {
+  nextWalletIndex?: number;
+  lastDetectionRunAt?: string | null;
+};
+
+const defaultWorkerState: StoredWorkerState = {
   nextWalletIndex: 0,
-  lastDetectionRunAt: null,
+  lastDetectionRunStartedAt: null,
+  lastDetectionRunCompletedAt: null,
   lastDetectionRunDurationMs: null,
 };
 
-function normalizeIndex(index: unknown, totalWallets?: number): number {
-  const parsed = typeof index === 'number' ? index : Number(index ?? 0);
-  if (!Number.isFinite(parsed) || parsed < 0) {
-    return 0;
+function coerceTimestamp(timestamp: unknown): string | null {
+  if (typeof timestamp === 'string' && timestamp.trim()) {
+    const parsed = Date.parse(timestamp);
+    return Number.isFinite(parsed) ? new Date(parsed).toISOString() : null;
   }
 
-  if (typeof totalWallets === 'number' && totalWallets > 0) {
-    return parsed % totalWallets;
+  return null;
+}
+
+function coerceDurationMs(duration: unknown): number | null {
+  if (typeof duration === 'number' && Number.isFinite(duration)) {
+    return duration;
   }
 
-  return Math.floor(parsed);
+  if (typeof duration === 'string' && duration.trim()) {
+    const parsed = Number(duration);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  return null;
+}
+
+function deriveStartedAt(
+  startedAt: string | null,
+  completedAt: string | null,
+  durationMs: number | null
+): string | null {
+  if (startedAt) {
+    return startedAt;
+  }
+
+  if (!completedAt || durationMs === null || durationMs === undefined) {
+    return null;
+  }
+
+  if (!Number.isFinite(durationMs)) {
+    return null;
+  }
+
+  const derived = Date.parse(completedAt) - durationMs;
+  if (!Number.isFinite(derived)) {
+    return null;
+  }
+
+  return new Date(derived).toISOString();
 }
 
 export async function readWorkerState(): Promise<WorkerState> {
-  const state = await readJsonFile(WORKER_STATE_FILE_PATH, defaultWorkerState);
+  const state = await readJsonFile<StoredWorkerState>(WORKER_STATE_FILE_PATH, defaultWorkerState);
+
+  const lastDetectionRunCompletedAt = coerceTimestamp(
+    state?.lastDetectionRunCompletedAt ?? state?.lastDetectionRunAt
+  );
+  const lastDetectionRunDurationMs = coerceDurationMs(state?.lastDetectionRunDurationMs);
+  const lastDetectionRunStartedAt = deriveStartedAt(
+    coerceTimestamp(state?.lastDetectionRunStartedAt),
+    lastDetectionRunCompletedAt,
+    lastDetectionRunDurationMs
+  );
+
   return {
-    nextWalletIndex: normalizeIndex(state?.nextWalletIndex),
-    lastDetectionRunAt: state?.lastDetectionRunAt ?? null,
-    lastDetectionRunDurationMs: Number.isFinite(state?.lastDetectionRunDurationMs)
-      ? Number(state.lastDetectionRunDurationMs)
-      : null,
+    lastDetectionRunStartedAt,
+    lastDetectionRunCompletedAt,
+    lastDetectionRunDurationMs,
   };
 }
 
 export async function writeWorkerState(state: Partial<WorkerState>): Promise<void> {
   const current = await readWorkerState();
   const merged: WorkerState = {
-    nextWalletIndex: normalizeIndex(state.nextWalletIndex ?? current.nextWalletIndex),
-    lastDetectionRunAt: state.lastDetectionRunAt ?? current.lastDetectionRunAt,
+    lastDetectionRunStartedAt: state.lastDetectionRunStartedAt ?? current.lastDetectionRunStartedAt,
+    lastDetectionRunCompletedAt:
+      state.lastDetectionRunCompletedAt ?? current.lastDetectionRunCompletedAt,
     lastDetectionRunDurationMs:
       state.lastDetectionRunDurationMs ?? current.lastDetectionRunDurationMs,
   };
@@ -50,21 +100,3 @@ export async function writeWorkerState(state: Partial<WorkerState>): Promise<voi
   await writeJsonFile(WORKER_STATE_FILE_PATH, merged);
 }
 
-export async function advanceWorkerWalletCursor({
-  processedWallets,
-  totalWallets,
-}: {
-  processedWallets: number;
-  totalWallets: number;
-}): Promise<void> {
-  const current = await readWorkerState();
-  const baseIndex = normalizeIndex(current.nextWalletIndex, totalWallets);
-
-  if (totalWallets === 0 || processedWallets <= 0) {
-    await writeWorkerState({ nextWalletIndex: baseIndex });
-    return;
-  }
-
-  const nextIndex = (baseIndex + processedWallets) % totalWallets;
-  await writeWorkerState({ nextWalletIndex: nextIndex });
-}

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -8,5 +8,5 @@
   "d1_databases": [
     { "binding": "DB", "database_name": "hypersignal", "database_id": "a1346ba1-4968-413a-81d0-ba49779f635a" }
   ],
-  "triggers": { "crons": ["*/5 * * * *"] }
+  "triggers": { "crons": ["*/10 * * * *"] }
 }


### PR DESCRIPTION
### **User description**
## Summary
- scale the signal detection runtime budget based on the number of tracked wallets so each run can finish even on the Cloudflare free tier
- surface the runtime target in detection logs to aid diagnosing future deadline skips
- note the runtime budget environment variables in the architecture overview

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68eb9b774c108324b08da148b308469f


___

### **PR Type**
Enhancement


___

### **Description**
- Scale signal detection runtime budget dynamically based on tracked wallet count

- Add cooldown enforcement to prevent overlapping worker runs on free tier

- Replace batch-based wallet scanning with full-scan approach per run

- Update cron schedule from 5-minute to 10-minute intervals


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Cron Trigger (10min)"] --> B["Cooldown Check"]
  B -- "Pass" --> C["Calculate Runtime Budget"]
  C --> D["Scan All Wallets"]
  D --> E["Update Worker State"]
  B -- "Skip" --> F["Return 202"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add cooldown enforcement to prevent overlapping worker runs</code></dd></summary>
<hr>

src/app/api/automation/run/route.ts

<ul><li>Add cooldown enforcement using <code>AUTOMATION_MIN_INTERVAL_MS</code> (10 minutes <br>default)<br> <li> Check last detection run timestamps to prevent overlapping executions<br> <li> Return 202 status with cooldown info when skipping runs<br> <li> Increase <code>AUTOMATION_ACTIVE_RUN_GRACE_MS</code> from 90s to 12 minutes</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/34/files#diff-28f3ab620f261fab44402f70e75926c78c9fdf981cd51d1b2475e1dab7f882e6">+47/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>signals.ts</strong><dd><code>Scale detection runtime budget dynamically with wallet count</code></dd></summary>
<hr>

src/server/services/signals.ts

<ul><li>Replace fixed runtime limit with dynamic budget based on wallet count<br> <li> Add <code>DETECTION_MIN_RUNTIME_BUDGET_MS</code> and <br><code>DETECTION_RUNTIME_BUDGET_PER_WALLET_MS</code> config<br> <li> Remove batch-based wallet processing in favor of scanning all wallets <br>per run<br> <li> Track both <code>lastDetectionRunStartedAt</code> and <code>lastDetectionRunCompletedAt</code> <br>separately<br> <li> Update warning threshold calculation to be relative to computed budget</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/34/files#diff-ef359f0c1cca09f9820cff3756bf16b7da64fb86b3dead740ae7eb8afae5f0c8">+44/-41</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>workerState.ts</strong><dd><code>Refactor worker state to track detection run lifecycle</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/workerState.ts

<ul><li>Replace <code>nextWalletIndex</code> and <code>lastDetectionRunAt</code> with separate <br>start/complete timestamps<br> <li> Add timestamp coercion and validation helpers<br> <li> Derive <code>lastDetectionRunStartedAt</code> from completion time and duration <br>when missing<br> <li> Remove <code>advanceWorkerWalletCursor</code> function (no longer needed)</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/34/files#diff-7d12d62be40882f0842b1463da93f36b7752c12aba930827ad4d4cca592d5803">+69/-37</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for new cron schedule and runtime behavior</code></dd></summary>
<hr>

README.md

<ul><li>Update cron schedule documentation from 5 minutes to 10 minutes<br> <li> Document cooldown enforcement in architecture overview<br> <li> Add runtime budget environment variables to architecture section</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/34/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>wrangler.jsonc</strong><dd><code>Update cron schedule to 10-minute intervals</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

wrangler.jsonc

- Change cron trigger from `*/5 * * * *` to `*/10 * * * *`


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/34/files#diff-21d9afdd0ffc457d5e1566045b68c0ca0ecc57ea3e5f704ee22164133e940736">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

