### PR TITLE
Log wallet scan counts per detection run

### DIFF
--- a/src/server/services/signals.ts
+++ b/src/server/services/signals.ts
@@ -599,6 +599,19 @@ export async function detectAndSaveSignals(options: DetectSignalsOptions = {}): 
   const addressesThisRun = rotatedAddresses;
   const walletBatches = chunkArray(addressesThisRun, DETECTION_MAX_WALLETS_PER_RUN);
 
+  await log({
+    level: 'INFO',
+    message: `Signal detection run starting with ${addressesThisRun.length} wallet${
+      addressesThisRun.length === 1 ? '' : 's'
+    } scheduled for scanning.`,
+    context: {
+      plannedWalletsThisRun: addressesThisRun.length,
+      totalTrackedWallets: trackedAddresses.length,
+      batchSizeLimit: DETECTION_MAX_WALLETS_PER_RUN,
+      walletBatchCount: walletBatches.length,
+    },
+  });
+
   const fillsByWallet: { address: string; fills: any[] }[] = [];
   let detectionAborted = false;
 


### PR DESCRIPTION
### **User description**
## Summary
- log each signal detection run with the number of wallets scheduled for scanning
- include additional context such as total tracked wallets, batch size limit, and wallet batch count in the log entry

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68ed06a6642c83248fe1b8a2d62672f6


___

### **PR Type**
Enhancement


___

### **Description**
- Add logging for signal detection runs with wallet scan counts

- Include context data: planned wallets, total tracked, batch size, and batch count

- Log message displays number of wallets scheduled for scanning


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Signal Detection Run"] --> B["Log Wallet Scan Info"]
  B --> C["Track Wallet Counts"]
  C --> D["Process Wallet Batches"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signals.ts</strong><dd><code>Add wallet scan count logging to detection runs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/signals.ts

<ul><li>Added logging statement before wallet batch processing begins<br> <li> Logs number of wallets scheduled for scanning with grammatically <br>correct singular/plural form<br> <li> Includes context object with <code>plannedWalletsThisRun</code>, <br><code>totalTrackedWallets</code>, <code>batchSizeLimit</code>, and <code>walletBatchCount</code></ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/44/files#diff-ef359f0c1cca09f9820cff3756bf16b7da64fb86b3dead740ae7eb8afae5f0c8">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

