### PR TITLE
Compact signal storage to avoid D1 size errors

### DIFF
--- a/src/server/services/performance.ts
+++ b/src/server/services/performance.ts
@@ -1,4 +1,5 @@
 import { getSignals } from './signals';
+import type { SignalClusterFill } from './signals';
 
 export interface WalletPerformance {
   rank: number;
@@ -41,7 +42,10 @@ export async function getPerformanceData(timeframe: string): Promise<WalletPerfo
       const isWin = signal.status === 'TP';
 
       const totalSignalSize = signal.clusterFills
-        ? signal.clusterFills.reduce((acc: number, fill: any) => acc + Math.abs(parseFloat(fill.sz)), 0)
+        ? signal.clusterFills.reduce(
+            (acc: number, fill: SignalClusterFill) => acc + Math.abs(parseFloat(fill.sz)),
+            0
+          )
         : signal.contributingWalletAddresses.length;
 
       if (totalSignalSize <= 0) {
@@ -59,7 +63,7 @@ export async function getPerformanceData(timeframe: string): Promise<WalletPerfo
       }
 
       if (signal.clusterFills) {
-        signal.clusterFills.forEach((fill: any) => {
+        signal.clusterFills.forEach((fill: SignalClusterFill) => {
           const fillSize = Math.abs(parseFloat(fill.sz));
           if (fillSize <= 0) {
             return;

--- a/src/server/services/signals.ts
+++ b/src/server/services/signals.ts
@@ -209,6 +209,7 @@ async function scheduleHyperliquidRequest<T>(task: () => Promise<T>): Promise<T>
 }
 
 const SIGNALS_FILE_PATH = 'signals.json';
+const MAX_STORED_SIGNALS = Math.max(1, Number(process.env.MAX_STORED_SIGNALS ?? 200));
 
 type SignalDirection = 'LONG' | 'SHORT';
 
@@ -250,6 +251,11 @@ function classifyFillForSignal(fill: any): { signalType: SignalDirection } | nul
   return null;
 }
 
+export interface SignalClusterFill {
+  walletAddress: string;
+  sz: string;
+}
+
 export interface Signal {
   id: string;
   pair: string;
@@ -268,17 +274,117 @@ export interface Signal {
   contributingWalletAddresses: string[];
   takeProfitTargets: string[];
   stopLoss: string;
-  clusterFills?: any[];
+  clusterFills?: SignalClusterFill[];
 }
 
 const defaultSignals: Signal[] = [];
 
+type SignalWithUnknownCluster = Omit<Signal, 'clusterFills' | 'contributingWalletAddresses' | 'contributingWallets'> & {
+  clusterFills?: unknown;
+  contributingWalletAddresses?: unknown;
+  contributingWallets?: unknown;
+};
+
+function normalizeClusterFills(fills: unknown): SignalClusterFill[] | undefined {
+  if (!Array.isArray(fills)) {
+    return undefined;
+  }
+
+  const contributions = new Map<string, number>();
+
+  for (const rawFill of fills) {
+    if (!rawFill) {
+      continue;
+    }
+
+    const fill = rawFill as Record<string, unknown>;
+    const wallet = typeof fill.walletAddress === 'string' && fill.walletAddress.trim().length > 0
+      ? fill.walletAddress.trim()
+      : undefined;
+    if (!wallet) {
+      continue;
+    }
+
+    const sizeSource = fill.sz ?? fill.size;
+    const parsedSize =
+      typeof sizeSource === 'number'
+        ? sizeSource
+        : typeof sizeSource === 'string'
+          ? Number.parseFloat(sizeSource)
+          : NaN;
+
+    if (!Number.isFinite(parsedSize)) {
+      continue;
+    }
+
+    const absolute = Math.abs(parsedSize);
+    if (absolute <= 0) {
+      continue;
+    }
+
+    contributions.set(wallet, (contributions.get(wallet) ?? 0) + absolute);
+  }
+
+  if (contributions.size === 0) {
+    return undefined;
+  }
+
+  return Array.from(contributions.entries()).map(([walletAddress, totalSize]) => ({
+    walletAddress,
+    sz: totalSize.toString(),
+  }));
+}
+
+function normalizeSignal(signal: SignalWithUnknownCluster): Signal {
+  const contributingWalletAddresses = Array.isArray(signal.contributingWalletAddresses)
+    ? signal.contributingWalletAddresses
+        .map((address) => (typeof address === 'string' ? address : String(address ?? '')))
+        .filter((address) => address.trim().length > 0)
+    : [];
+
+  const clusterFills = normalizeClusterFills(signal.clusterFills);
+
+  const normalized: Signal = {
+    ...(signal as Signal),
+    contributingWalletAddresses,
+    contributingWallets:
+      typeof signal.contributingWallets === 'number' && Number.isFinite(signal.contributingWallets)
+        ? signal.contributingWallets
+        : contributingWalletAddresses.length,
+    clusterFills: clusterFills ?? undefined,
+  };
+
+  return normalized;
+}
+
+function resolveTimestamp(value: string): number {
+  if (typeof value !== 'string') {
+    return 0;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+function normalizeSignals(signals: readonly SignalWithUnknownCluster[]): Signal[] {
+  return signals
+    .map((signal) => normalizeSignal(signal))
+    .sort((a, b) => resolveTimestamp(b.timestamp) - resolveTimestamp(a.timestamp))
+    .slice(0, MAX_STORED_SIGNALS);
+}
+
 async function readSignals(): Promise<Signal[]> {
-  return readJsonFile(SIGNALS_FILE_PATH, defaultSignals);
+  const signals = await readJsonFile(SIGNALS_FILE_PATH, defaultSignals);
+  if (!Array.isArray(signals)) {
+    return defaultSignals;
+  }
+
+  return normalizeSignals(signals as SignalWithUnknownCluster[]);
 }
 
 async function writeSignals(signals: Signal[]): Promise<void> {
-  await writeJsonFile(SIGNALS_FILE_PATH, signals);
+  const normalized = normalizeSignals(signals);
+  await writeJsonFile(SIGNALS_FILE_PATH, normalized);
 }
 
 async function getMarkPrice(coin: string): Promise<string> {
@@ -977,7 +1083,7 @@ export async function detectAndSaveSignals(options: DetectSignalsOptions = {}): 
       currentPrice: currentPrice.toFixed(4),
       takeProfitTargets: takeProfitLevels,
       stopLoss: stopLossLevel,
-      clusterFills: bestCluster,
+      clusterFills: normalizeClusterFills(bestCluster) ?? undefined,
     };
 
     if (overallDeadlineExceeded()) {


### PR DESCRIPTION
### **User description**
## Summary
- aggregate and normalize stored signal cluster fills so D1 rows remain under size limits
- cap the number of stored signals when persisting and reuse the normalizer on reads/writes
- update performance calculations to use the new cluster fill type information

## Testing
- npm run typecheck

------
https://chatgpt.com/codex/tasks/task_b_68f11ae0f7f4832498ac86c990d42155


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implement signal normalization to enforce D1 storage limits

- Add `MAX_STORED_SIGNALS` configuration with default of 200

- Define `SignalClusterFill` interface for type-safe cluster fills

- Normalize signals on read/write to aggregate wallet contributions

- Replace `any` types with proper TypeScript interfaces


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw Signals"] -->|normalizeSignals| B["Sorted & Capped"]
  B -->|normalizeClusterFills| C["Aggregated Fills"]
  C -->|writeSignals| D["D1 Storage"]
  D -->|readSignals| E["Normalized Signals"]
  E -->|getPerformanceData| F["Type-safe Processing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>signals.ts</strong><dd><code>Add signal normalization and storage limits</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/signals.ts

<ul><li>Add <code>MAX_STORED_SIGNALS</code> constant with environment variable support<br> <li> Export <code>SignalClusterFill</code> interface for wallet address and size pairs<br> <li> Implement <code>normalizeClusterFills()</code> to aggregate fills by wallet and <br>validate data<br> <li> Implement <code>normalizeSignal()</code> to validate and normalize individual <br>signals<br> <li> Implement <code>normalizeSignals()</code> to sort by timestamp and cap to max <br>stored signals<br> <li> Update <code>readSignals()</code> to normalize loaded signals with validation<br> <li> Update <code>writeSignals()</code> to normalize before persisting<br> <li> Apply normalization to cluster fills in <code>detectAndSaveSignals()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/48/files#diff-ef359f0c1cca09f9820cff3756bf16b7da64fb86b3dead740ae7eb8afae5f0c8">+110/-4</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>performance.ts</strong><dd><code>Replace any types with SignalClusterFill</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/server/services/performance.ts

<ul><li>Import <code>SignalClusterFill</code> type from signals module<br> <li> Replace <code>any</code> type with <code>SignalClusterFill</code> in cluster fills reduce <br>operation<br> <li> Replace <code>any</code> type with <code>SignalClusterFill</code> in cluster fills forEach <br>iteration</ul>


</details>


  </td>
  <td><a href="https://github.com/amiralysaleh/hypersignal/pull/48/files#diff-2d35e4b71480ea2720c0709751c7d6702e64eafb9500997bbdf4f50655c27095">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

